### PR TITLE
enhancement: fix prop extensions type hint & refactor useI18n hook

### DIFF
--- a/.changeset/fix-yiieditor-prop-types.md
+++ b/.changeset/fix-yiieditor-prop-types.md
@@ -1,0 +1,5 @@
+---
+"@yiitap/vue": patch
+---
+
+fix(vue): Fix prop extensions type hint for YiiEditor component

--- a/.changeset/refactor-use-i18n.md
+++ b/.changeset/refactor-use-i18n.md
@@ -1,0 +1,5 @@
+---
+"@yiitap/vue": patch
+---
+
+perf(vue): Refactor useI18n hook for better performance

--- a/apps/vue/src/components/Demo.vue
+++ b/apps/vue/src/components/Demo.vue
@@ -157,7 +157,7 @@ import {
   type AiOptions,
   type SideMenuAddType,
 } from '@yiitap/vue'
-import type { Editor } from '@yiitap/vue'
+import type { Editor, ExtensionsProp } from '@yiitap/vue'
 import { SupportLanguages } from '@yiitap/i18n'
 import { HocuspocusProvider } from '@hocuspocus/provider'
 import * as Y from 'yjs'
@@ -200,7 +200,7 @@ const aiOptions = computed(() => {
 })
 
 const editorOptions = computed(() => {
-  const extensions = [
+  const extensions: ExtensionsProp[] = [
     OStarterKit.configure({
       UniqueID: true,
       OSlash: {
@@ -227,7 +227,7 @@ const editorOptions = computed(() => {
     'OMultiColumn',
     'OShortcut',
     'OVideo',
-  ] as any[]
+  ]
   if (collabReady.value) {
     extensions.push(
       {

--- a/apps/vue/src/components/Demo.vue
+++ b/apps/vue/src/components/Demo.vue
@@ -177,7 +177,6 @@ const darkMode = ref(false)
 const editable = ref(true)
 const source = ref('default')
 const showDrawer = ref(false)
-provide('locale', locale)
 
 // Collaboration
 const ydoc = shallowRef<Y.Doc | null>(null)

--- a/packages/vue/src/components/YiiEditor.vue
+++ b/packages/vue/src/components/YiiEditor.vue
@@ -70,7 +70,7 @@ import { isExtensionInstalled } from '../utils'
 import {
   OPlaceholder,
   createExtensionList,
-  type AnyExtension,
+  type ExtensionsProp,
 } from '../extensions'
 import { type SideMenuAddType } from '../types/types'
 
@@ -173,7 +173,7 @@ const props = defineProps({
    * <a href="https://github.com/pileax-ai/yiitap/blob/main/packages/vue/src/extensions/index.ts" target="_blank">BuiltinExtensions</a>.
    */
   extensions: {
-    type: Array as () => AnyExtension[],
+    type: Array as () => ExtensionsProp[],
     default: () => [],
   },
   /**

--- a/packages/vue/src/components/YiiEditor.vue
+++ b/packages/vue/src/components/YiiEditor.vue
@@ -258,7 +258,7 @@ const emit = defineEmits<{
   (e: 'update', payload: { editor: Editor }): void
 }>()
 
-const { tr } = useI18n()
+const { tr, setLocale } = useI18n()
 const darkModeAlt = ref(false)
 const isEditable = ref(true)
 const localeAlt = ref('en')
@@ -407,6 +407,8 @@ watch(
   () => props.locale,
   (newValue) => {
     localeAlt.value = newValue
+    setLocale(newValue)
+    editor.value?.view.dispatch(editor.value?.view.state.tr)
   }
 )
 
@@ -431,6 +433,8 @@ onBeforeMount(() => {
   aiOptionsAlt.value = props.aiOptions
   darkModeAlt.value = props.darkMode
   localeAlt.value = props.locale
+  setLocale(props.locale)
+  editor.value?.view.dispatch(editor.value?.view.state.tr)
 })
 
 defineExpose({

--- a/packages/vue/src/extensions/factory.ts
+++ b/packages/vue/src/extensions/factory.ts
@@ -325,6 +325,11 @@ export const extensionRegistry: {
 /**
  * Derived Types for IntelliSense
  */
+export type ExtensionsProp = ExtensionName | ExtensionItem | AnyExtension[]
+
+/**
+ * Derived Types for IntelliSense
+ */
 export type ExtensionName = keyof typeof extensionRegistry
 
 /**
@@ -373,7 +378,7 @@ export const createExtension = <T extends ExtensionName>(
  * Allows passing either a simple string or a full { name, configure } object
  */
 export const createExtensionList = (
-  items: (ExtensionName | ExtensionItem)[]
+  items: ExtensionsProp[]
 ): AnyExtension[] => {
   return items.flatMap((item) => {
     // 1. If it's an array (e.g., OStarterKit.configure())

--- a/packages/vue/src/hooks/useI18n.ts
+++ b/packages/vue/src/hooks/useI18n.ts
@@ -1,28 +1,41 @@
-import { computed, inject } from 'vue'
+import { computed, inject, ref } from 'vue'
 import { getMessage } from '@yiitap/i18n'
 
-export default function () {
-  const locale = inject('locale', { value: 'en' })
+const locale = ref('en')
 
-  const message = computed(() => {
-    return getMessage(locale.value)
-  })
+const message = computed(() => {
+  return getMessage(locale.value)
+})
 
-  const languageName = computed(() => {
-    return message.value?.name || 'English'
-  })
+const languageName = computed(() => {
+  return message.value?.name || 'English'
+})
 
-  function tr(key: string) {
-    return key.split('.').reduce((o, i) => {
-      if (o) return o[i]
-    }, message.value)
+const tr = (key: string) => {
+  return key.split('.').reduce((o, i) => {
+    if (o) return o[i]
+  }, message.value)
+}
+
+const setLocale = (inputLang: string) => {
+  locale.value = inputLang
+}
+
+export default () => {
+  const injectLocale = inject('locale', locale)
+  if (
+    typeof injectLocale === 'object' &&
+    injectLocale.value &&
+    injectLocale.value !== locale.value
+  ) {
+    locale.value = injectLocale.value
   }
 
   return {
     languageName,
     locale,
     message,
-
     tr,
+    setLocale,
   }
 }


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->
1. 修改了 `YiiEditor.vue` 组件对 `extensions` 这个 prop 声明的类型
  `YiiEditor.vue` 组件声明的 `extensions` 类型是 `AnyExtension[]` 实际上是错误的类型，这会导致 TypeScript 报这个 prop 类型不对（虽然有警告也能运行），最后无奈只能写成类似下面的代码，根据 `createExtensionList()` 可以看到是支持至少三种类型。
```typescript
const extensions = OStarterKit.configure({
  UniqueID: true,
})
extensions.push(...createExtensionList(['OShortcut']))
```
3. 重构 useI18n 钩子以获得更好的性能
  默认的 `useI18n()` 存在性能问题，所有调用了 `useI18n()` 的组件每次刷新语言调用两次 `computed()`，实际上这个只需要在 hook 被加载的时候调用一次即可。

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
